### PR TITLE
Just exit(1) on an exception.

### DIFF
--- a/EndlessTimer.js
+++ b/EndlessTimer.js
@@ -1,12 +1,13 @@
 const GLib = imports.gi.GLib;
 const Mainloop = imports.mainloop;
+const System = imports.system;
 
 function quitMainLoopOnException(fn) {
     try {
         fn();
     } catch (e) {
         Mainloop.quit();
-        throw e;
+        System.exit(1);
     }
 }
 


### PR DESCRIPTION
Re-throwing won't work because our exception will end up
at the GObject boundary to GLib's main loop and the best
we will get is an error message from JS. It won't actually
abort the program.

[endlessm/eos-jasmine#23]
