### PR TITLE
Make sure the name the mainloop when we want to refer to it.

### DIFF
--- a/EndlessConsoleReporter.js
+++ b/EndlessConsoleReporter.js
@@ -1,4 +1,5 @@
 const Gio = imports.gi.Gio;
+const Mainloop = imports.mainloop;
 
 /* We define our own console reporter here, because the default one is not very useful */
 const EndlessConsoleReporter = function () {
@@ -213,10 +214,11 @@ let defaultConsoleReporter = (EndlessConsoleReporter())({
     },
     timer: new jasmine.Timer(),
     onComplete: function (success) {
-        Mainloop.quit();
         _stdout.close(null);
 
-        if (!success)
+        if (success === false)
             throw new Error('Test suite failed');
+        else
+            Mainloop.quit("jasmine");
     }
 });

--- a/EndlessTimer.js
+++ b/EndlessTimer.js
@@ -6,7 +6,7 @@ function quitMainLoopOnException(fn) {
     try {
         fn();
     } catch (e) {
-        Mainloop.quit();
+        Mainloop.quit("jasmine");
         System.exit(1);
     }
 }

--- a/eos-jasmine-run
+++ b/eos-jasmine-run
@@ -31,4 +31,4 @@ GLib.idle_add(GLib.PRIORITY_DEFAULT, function () {
     return false;
 }, null);
 
-Mainloop.run();
+Mainloop.run("jasmine");

--- a/runner.js
+++ b/runner.js
@@ -95,7 +95,7 @@ function executeSpecs(suites, baseDir) {
         return false;
     }, null);
 
-    Mainloop.run();
+    Mainloop.run("jasmine");
 }
 
 function _bootstrap(jasmineDir) {


### PR DESCRIPTION
Also fix missing import which was breaking on newer versions of
Gjs.

[endlessm/eos-jasmine#22]
