### PR TITLE
Print message when quitting on exception

### DIFF
--- a/EndlessTimer.js
+++ b/EndlessTimer.js
@@ -7,6 +7,8 @@ function quitMainLoopOnException(fn) {
         fn();
     } catch (e) {
         Mainloop.quit("jasmine");
+        printerr('Exception occurred outside of a test suite:', e);
+        printerr(e.stack);
         System.exit(1);
     }
 }


### PR DESCRIPTION
This makes sure that an explanatory message is printed when quitting
the main loop due to an exception in a test suite but outside a test
(e.g. in a beforeEach function.)

[endlessm/eos-sdk#737]
