### PR TITLE
Improve readability of test-suite.log.

### DIFF
--- a/EndlessConsoleReporter.js
+++ b/EndlessConsoleReporter.js
@@ -1,5 +1,6 @@
 const Gio = imports.gi.Gio;
 const Mainloop = imports.mainloop;
+const System = imports.system;
 
 /* We define our own console reporter here, because the default one is not very useful */
 const EndlessConsoleReporter = function () {
@@ -217,7 +218,7 @@ let defaultConsoleReporter = (EndlessConsoleReporter())({
         _stdout.close(null);
 
         if (success === false)
-            throw new Error('Test suite failed');
+            System.exit(1);
         else
             Mainloop.quit("jasmine");
     }


### PR DESCRIPTION
When running make check in a repo with a failing test that uses this
reporter, the output in test-suite.log is quite noisy, complaining about
an exception being raised outside of the test suite. We exit with a
non-zero exit code instead so that test-suite.log still considers the
failed test to have failed but less noise is produced.

[endlessm/eos-sdk#2017]